### PR TITLE
Add empty file to trigger PR testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3268,7 +3268,7 @@ Other Style Guides
     ```
 
   <a name="naming--Acronyms-and-Initialisms"></a>
-  - [23.9](#naming--Acronyms-and-Initialisms) Acronyms and initialisms should always be all capitalized, or all lowercased.
+  - [23.9](#naming--Acronyms-and-Initialisms) Acronyms and initialisms should always be all uppercased, or all lowercased.
 
     > Why? Names are for readability, not to appease a computer algorithm.
 


### PR DESCRIPTION
The examples and the reasoning indicates the author of the rule meant uppercase instead of capitalization. According to Wikipedia, capitalization is "writing a word with its first letter as a capital letter (uppercase letter) and the remaining letters in lower case", while the rule apparently tries to prevent exactly that.